### PR TITLE
"Advertised Start" date has been removed from the Council Website 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.6)
       connection_pool (~> 2.2, >= 2.2.4)
+    nokogiri (1.16.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.8-x86_64-linux)
       racc (~> 1.4)
     parallel (1.27.0)
@@ -96,6 +98,7 @@ GEM
       simplecov
       terminal-table
     simplecov-html (0.13.1)
+    sqlite3 (1.6.9-arm64-darwin)
     sqlite3 (1.6.9-x86_64-linux)
     sqlite_magic (0.0.6)
       sqlite3
@@ -108,6 +111,7 @@ GEM
     webrobots (0.1.2)
 
 PLATFORMS
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/scraper.rb
+++ b/scraper.rb
@@ -29,8 +29,8 @@ table.search("tr").each do |r|
   record = {
     council_reference: r.search("td")[2].inner_text.strip,
     address: address,
-    on_notice_from: Date.parse(r.search("td")[3].inner_text).to_s,
-    on_notice_to: Date.parse(r.search("td")[4].inner_text).to_s,
+    on_notice_from: "",
+    on_notice_to: Date.parse(r.search("td")[3].inner_text).to_s,
     info_url: application_url,
     description: description,
     date_scraped: Date.today.to_s,


### PR DESCRIPTION
Resolves:
- https://github.com/planningalerts-scrapers/issues/issues/1188

Fix:
- The Advertised Planning Applications page on the council website no longer has a "Advertised start" date. This PR sets the "Advertised Start" date without making any further changes.